### PR TITLE
Add relay.yozora.world info

### DIFF
--- a/awesome-nostr-japan.toml
+++ b/awesome-nostr-japan.toml
@@ -106,6 +106,14 @@ caption = "Relays"
   author_name = ["jiftechnify"]
   author_url = ["https://github.com/jiftechnify"]
 
+  [Relays.relay_yozora_world]
+  name = ""
+  address= "wss://relay.yozora.world"
+  description = "Paid relay via Stalink's satellite network"
+  description_ja = "Starlinkの衛星回線のみで運用されている有料リレー"
+  author_name = ["godzhigella"]
+  author_url = ["https://github.com/higedamc"]
+
 [WebServices]
 
 caption = "Web Services"


### PR DESCRIPTION
Starlinkの衛星回線のみで運用している有料リレーの情報を追加。