### PR TITLE
Add permissions to generate workflow

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -4,7 +4,9 @@ on:
   push:
     branches:
       - main
-  pull_request:
+
+permissions:
+  contents: write
 
 jobs:
   generate:


### PR DESCRIPTION
generate workflowの実行時にリポジトリを操作する権限がないというエラーが出るためpermissionsを設定します。

```
[main 8bed8b9] generate README.md
 2 files changed, 14 insertions(+)
remote: Permission to nostr-jp/awesome-nostr-japan.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/nostr-jp/awesome-nostr-japan/': The requested URL returned error: 403
Error: Process completed with exit code 128.
```